### PR TITLE
Fixes vertical alignment and inverted spacing in LinearLayout

### DIFF
--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/container/LinearLayout.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/container/LinearLayout.kt
@@ -208,8 +208,8 @@ open class LinearLayout<T : GameComponentView>(
 		val newTotalContentHeight = totalContentHeight + (observableComponents.size - 1) * newSpacing
 		val initial = when (alignment.verticalAlignment) {
 			VerticalAlignment.TOP -> 0.0
-			VerticalAlignment.CENTER -> (width - newTotalContentHeight) / 2
-			VerticalAlignment.BOTTOM -> width - newTotalContentHeight
+			VerticalAlignment.CENTER -> (height - newTotalContentHeight) / 2
+			VerticalAlignment.BOTTOM -> height - newTotalContentHeight
 		}
 		observableComponents.fold(initial) { acc: Double, component: T ->
 			component.posYProperty.setSilent(acc)

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/container/LinearLayout.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/container/LinearLayout.kt
@@ -173,7 +173,7 @@ open class LinearLayout<T : GameComponentView>(
 		val totalContentWidth: Double = observableComponents.sumOf { it.width }
 		val totalContentWidthWithSpacing = totalContentWidth + (observableComponents.size - 1) * spacing
 		val newSpacing: Double = if (totalContentWidthWithSpacing > width) {
-			-((totalContentWidth - width) / (observableComponents.size - 1)) //ignore user defined spacing
+			-(minOf((totalContentWidth - width) / (observableComponents.size - 1), totalContentWidth / observableComponents.size)) //ignore user defined spacing
 		} else {
 			spacing //use user defined spacing
 		}
@@ -201,7 +201,7 @@ open class LinearLayout<T : GameComponentView>(
 		val totalContentHeight: Double = observableComponents.sumOf { it.height }
 		val totalContentHeightWithSpacing = totalContentHeight + (observableComponents.size - 1) * spacing
 		val newSpacing: Double = if (totalContentHeightWithSpacing > height) {
-			-((totalContentHeight - height) / (observableComponents.size - 1)) //ignore user defined spacing
+			-(minOf((totalContentHeight - height) / (observableComponents.size - 1), totalContentHeight / observableComponents.size)) //ignore user defined spacing
 		} else {
 			spacing //use user defined spacing
 		}


### PR DESCRIPTION
Vertical alignment now properly aligns the content according to the boundaries of the LinearLayout.

Inserting content that is too big for the LinearLayout-Container no longer produces a semantically incorrect spacing that causes the content to grow in the inverted direction.