### PR TITLE
Fix example: Adding a Button to GridPane

### DIFF
--- a/docs/components/layout/layout.md
+++ b/docs/components/layout/layout.md
@@ -97,7 +97,7 @@ val content = grid[0,2]
 will retrieve the content of cell ``[0,2]``. Empty cells contain ``null``.
 
 ````kotlin
-grid[0,2] = Button("Hello")
+grid[0,2] = Button(text="Hello")
 ````
 will replace the content of cell ``[0,2]`` with a button. To remove elements use
 ````kotlin


### PR DESCRIPTION
The example code for adding and removing components to a `GridPane` does not work. 
[Source](https://tudo-aqua.github.io/bgw/components/layout/layout.html#gridpane)