### PR TITLE
Make prompt in TextArea and TextField mutable

### DIFF
--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
@@ -101,6 +101,9 @@ internal class UINodeBuilder {
 
 			node.textProperty().bindTextProperty(textArea)
 			node.promptText = textArea.prompt
+			textArea.onUpdatePrompt = {
+				node.promptText = it
+			}
 			return node
 		}
 
@@ -112,6 +115,9 @@ internal class UINodeBuilder {
 
 			node.textProperty().bindTextProperty(textField)
 			node.promptText = textField.prompt
+			textField.onUpdatePrompt = {
+				node.promptText = it
+			}
 			return node
 		}
 

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
@@ -42,17 +42,25 @@ import tools.aqua.bgw.util.Font
  *  @see TextField
  */
 open class TextArea(
-	posX: Number = 0,
-	posY: Number = 0,
-	width: Number = DEFAULT_TEXT_AREA_WIDTH,
-	height: Number = DEFAULT_TEXT_AREA_HEIGHT,
-	text: String = "",
-	font: Font = Font(),
-	val prompt: String = "",
+    posX: Number = 0,
+    posY: Number = 0,
+    width: Number = DEFAULT_TEXT_AREA_WIDTH,
+    height: Number = DEFAULT_TEXT_AREA_HEIGHT,
+    text: String = "",
+    font: Font = Font(),
+    prompt: String = "",
+    internal var onUpdatePrompt: ((prompt: String) -> Unit)? = null,
 ) : TextInputUIComponent(
-	posX = posX,
-	posY = posY,
-	width = width,
-	height = height,
-	text = text,
-	font = font)
+    posX = posX,
+    posY = posY,
+    width = width,
+    height = height,
+    text = text,
+    font = font
+) {
+    var prompt = prompt
+        set(value) {
+            field = value
+            onUpdatePrompt?.invoke(value)
+        }
+}

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
@@ -39,17 +39,25 @@ import tools.aqua.bgw.util.Font
  * @see TextArea
  */
 open class TextField(
-	posX: Number = 0,
-	posY: Number = 0,
-	width: Number = DEFAULT_TEXT_FIELD_WIDTH,
-	height: Number = DEFAULT_TEXT_FIELD_HEIGHT,
-	text: String = "",
-	font: Font = Font(),
-	val prompt: String = "",
+    posX: Number = 0,
+    posY: Number = 0,
+    width: Number = DEFAULT_TEXT_FIELD_WIDTH,
+    height: Number = DEFAULT_TEXT_FIELD_HEIGHT,
+    text: String = "",
+    font: Font = Font(),
+    prompt: String = "",
+    internal var onUpdatePrompt: ((prompt: String) -> Unit)? = null,
 ) : TextInputUIComponent(
-	posX = posX,
-	posY = posY,
-	width = width,
-	height = height,
-	text = text,
-	font = font)
+    posX = posX,
+    posY = posY,
+    width = width,
+    height = height,
+    text = text,
+    font = font
+) {
+    var prompt = prompt
+        set(value) {
+            field = value
+            onUpdatePrompt?.invoke(value)
+        }
+}


### PR DESCRIPTION
Make prompt in TextArea and TextField mutable and update the internal representation accordingly on changes.

I am not sure if this is how this is meant to be done in bgw, so I am very open to feedback.

Close #171 