### PR TITLE
Implement property for TextInputUIComponent prompt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@
 [![KDocs](https://img.shields.io/badge/KDoc-Overview-yellowgreen)](https://tudo-aqua.github.io/bgw/kotlin-docs/)
 [![Detekt-Pages](https://img.shields.io/badge/Detekt-Report-yellowgreen)](https://tudo-aqua.github.io/bgw/detekt)
 
+------------
+
+BoardGameWork is a framework for creating 2D board game applications. 
+
+Read on [how to get started](https://tudo-aqua.github.io/bgw/), or take a look at the complete [API documentation](https://tudo-aqua.github.io/bgw/kotlin-docs/).

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/LayoutNodeBuilder.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/LayoutNodeBuilder.kt
@@ -92,7 +92,6 @@ internal class LayoutNodeBuilder {
 			gridView.renderedRowHeights = DoubleArray(grid.rows) {
 				grid.getRow(it).maxOf { entry -> entry?.let { t ->
 					val fixedHeight = grid.getRowHeight(it)
-					
 					if(fixedHeight == ROW_HEIGHT_AUTO)
 						t.layoutBounds.height + t.posY
 					else
@@ -102,7 +101,6 @@ internal class LayoutNodeBuilder {
 			gridView.renderedColWidths = DoubleArray(grid.columns) {
 				grid.getColumn(it).maxOf { entry -> entry?.let { t ->
 					val fixedWidth = grid.getColumnWidth(it)
-					
 					if(fixedWidth == COLUMN_WIDTH_AUTO)
 						t.layoutBounds.width + t.posX
 					else

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
@@ -303,8 +303,6 @@ internal class UINodeBuilder {
 		private fun javafx.beans.property.StringProperty.bindPromptProperty(labeled: TextInputUIComponent) {
 			//Framework -> JavaFX
 			labeled.promptProperty.setGUIListenerAndInvoke(labeled.prompt) { _, nV -> value = nV }
-			//JavaFX -> Framework
-			addListener { _, _, new -> labeled.prompt = new }
 		}
 
 		/**

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/builder/UINodeBuilder.kt
@@ -100,7 +100,7 @@ internal class UINodeBuilder {
 			val node = javafx.scene.control.TextArea(textArea.textProperty.value)
 
 			node.textProperty().bindTextProperty(textArea)
-			node.promptText = textArea.prompt
+			node.promptTextProperty().bindPromptProperty(textArea)
 			return node
 		}
 
@@ -111,7 +111,7 @@ internal class UINodeBuilder {
 			val node = javafx.scene.control.TextField(textField.textProperty.value)
 
 			node.textProperty().bindTextProperty(textField)
-			node.promptText = textField.prompt
+			node.promptTextProperty().bindPromptProperty(textField)
 			return node
 		}
 
@@ -295,6 +295,16 @@ internal class UINodeBuilder {
 			labeled.textProperty.setGUIListenerAndInvoke(labeled.text) { _, nV -> value = nV }
 			//JavaFX -> Framework
 			addListener { _, _, new -> labeled.text = new }
+		}
+
+		/**
+		 * Binds [TextInputUIComponent.promptProperty].
+		 */
+		private fun javafx.beans.property.StringProperty.bindPromptProperty(labeled: TextInputUIComponent) {
+			//Framework -> JavaFX
+			labeled.promptProperty.setGUIListenerAndInvoke(labeled.prompt) { _, nV -> value = nV }
+			//JavaFX -> Framework
+			addListener { _, _, new -> labeled.prompt = new }
 		}
 
 		/**

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
@@ -39,7 +39,7 @@ import tools.aqua.bgw.util.Font
  *        This gets displayed as a prompt to the user whenever the label is an empty string.
  *        Default: empty string.
  *
- *  @see TextField
+ * @see TextField
  */
 open class TextArea(
 	posX: Number = 0,
@@ -48,11 +48,12 @@ open class TextArea(
 	height: Number = DEFAULT_TEXT_AREA_HEIGHT,
 	text: String = "",
 	font: Font = Font(),
-	val prompt: String = "",
+	prompt: String = "",
 ) : TextInputUIComponent(
 	posX = posX,
 	posY = posY,
 	width = width,
 	height = height,
 	text = text,
+	prompt = prompt,
 	font = font)

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextArea.kt
@@ -36,8 +36,8 @@ import tools.aqua.bgw.util.Font
  * @param height Height for this [TextArea]. Default: [DEFAULT_TEXT_AREA_HEIGHT].
  * @param text Initial text for this [TextArea]. Default: empty String.
  * @param prompt Prompt for this [TextArea].
- *        This gets displayed as a prompt to the user whenever the label is an empty string.
- *        Default: empty string.
+ *        This gets displayed as a prompt to the user whenever the label is an empty String.
+ *        Default: empty String.
  *
  * @see TextField
  */

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
@@ -33,7 +33,7 @@ import tools.aqua.bgw.util.Font
  * @param width Width for this [TextField]. Default: [DEFAULT_TEXT_FIELD_WIDTH].
  * @param height Height for this [TextField]. Default: [DEFAULT_TEXT_FIELD_HEIGHT].
  * @param text Initial text for this [TextField]. Default: empty String.
- * @param prompt Prompt for this [TextArea].
+ * @param prompt Prompt for this [TextField].
  *        This gets displayed as a prompt to the user whenever the label is an empty string.
  *        Default: empty string.
  *

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
@@ -33,8 +33,9 @@ import tools.aqua.bgw.util.Font
  * @param width Width for this [TextField]. Default: [DEFAULT_TEXT_FIELD_WIDTH].
  * @param height Height for this [TextField]. Default: [DEFAULT_TEXT_FIELD_HEIGHT].
  * @param text Initial text for this [TextField]. Default: empty String.
- * @param prompt Prompt for this [TextField]. This gets displayed as a prompt to the user whenever the label is an
- * empty string. Default: empty string.
+ * @param prompt Prompt for this [TextArea].
+ *        This gets displayed as a prompt to the user whenever the label is an empty string.
+ *        Default: empty string.
  *
  * @see TextArea
  */
@@ -45,11 +46,12 @@ open class TextField(
 	height: Number = DEFAULT_TEXT_FIELD_HEIGHT,
 	text: String = "",
 	font: Font = Font(),
-	val prompt: String = "",
+	prompt: String = "",
 ) : TextInputUIComponent(
 	posX = posX,
 	posY = posY,
 	width = width,
 	height = height,
 	text = text,
+	prompt = prompt,
 	font = font)

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextField.kt
@@ -34,8 +34,8 @@ import tools.aqua.bgw.util.Font
  * @param height Height for this [TextField]. Default: [DEFAULT_TEXT_FIELD_HEIGHT].
  * @param text Initial text for this [TextField]. Default: empty String.
  * @param prompt Prompt for this [TextField].
- *        This gets displayed as a prompt to the user whenever the label is an empty string.
- *        Default: empty string.
+ *        This gets displayed as a prompt to the user whenever the label is an empty String.
+ *        Default: empty String.
  *
  * @see TextArea
  */

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextInputUIComponent.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextInputUIComponent.kt
@@ -32,7 +32,7 @@ import tools.aqua.bgw.visual.Visual
  * @param width Width for this [TextInputUIComponent].
  * @param height Height for this [TextInputUIComponent].
  * @param text Text for this [TextInputUIComponent].
- * @param prompt Prompt for this [TextArea].
+ * @param prompt Prompt for this [TextInputUIComponent].
  * @param font Font to be used for the [text].
  */
 sealed class TextInputUIComponent(

--- a/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextInputUIComponent.kt
+++ b/bgw-core/src/main/kotlin/tools/aqua/bgw/components/uicomponents/TextInputUIComponent.kt
@@ -32,6 +32,7 @@ import tools.aqua.bgw.visual.Visual
  * @param width Width for this [TextInputUIComponent].
  * @param height Height for this [TextInputUIComponent].
  * @param text Text for this [TextInputUIComponent].
+ * @param prompt Prompt for this [TextArea].
  * @param font Font to be used for the [text].
  */
 sealed class TextInputUIComponent(
@@ -40,6 +41,7 @@ sealed class TextInputUIComponent(
 	width: Number,
 	height: Number,
 	text: String,
+	prompt: String,
 	font: Font,
 ) : UIComponent(
 	posX = posX,
@@ -65,5 +67,23 @@ sealed class TextInputUIComponent(
 		get() = textProperty.value
 		set(value) {
 			textProperty.value = value
+		}
+
+	/**
+	 * [Property] for the prompt of this [TextInputUIComponent].
+	 *
+	 * @see prompt
+	 */
+	val promptProperty: StringProperty = StringProperty(prompt)
+
+	/**
+	 * Prompt of this [TextInputUIComponent].
+	 *
+	 * @see promptProperty
+	 */
+	var prompt: String
+		get() = promptProperty.value
+		set(value) {
+			promptProperty.value = value
 		}
 }


### PR DESCRIPTION
Allows updating the prompt of a TextField or TextArea.

Supersedes #172, which was filed against the wrong branch.
Now uses observable properties to update the internal JavaFX representation.

Closes #171

