### PR TITLE
Introduce global Maven metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,4 +15,21 @@
  * limitations under the License.
  */
 
+import tools.aqua.APACHE_2
+import tools.aqua.GlobalMavenMetadataExtension.Developer
+import tools.aqua.GlobalMavenMetadataExtension.GithubProject
+
 plugins { id("tools.aqua.bgw.root-conventions") }
+
+mavenMetadata {
+  developers.addAll(
+      Developer("Simon Dierl", "simon.dierl@tu-dortmund.de"),
+      Developer("Stefan Naujokat", "stefan.naujokat@tu-dortmund.de"),
+      Developer("Till Schallau", "till.schallau@tu-dortmund.de"),
+      Developer("Amin Bouzerda", "amin.bouzerda@tu-dortmund.de"),
+      Developer("Dominik Mäckel", "dominik.maeckel@tu-dortmund.de"),
+      Developer("Fabian Klümpers", "fabian.kluempers@tu-dortmund.de"),
+  )
+  githubProject.set(GithubProject("tudo-aqua", "bgw"))
+  licenses.addAll(APACHE_2)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ import tools.aqua.GlobalMavenMetadataExtension.GithubProject
 
 plugins { id("tools.aqua.bgw.root-conventions") }
 
+group = "tools.aqua"
+
 mavenMetadata {
   developers.addAll(
       Developer("Simon Dierl", "simon.dierl@tu-dortmund.de"),

--- a/buildSrc/src/main/kotlin/tools.aqua.bgw.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools.aqua.bgw.publish-conventions.gradle.kts
@@ -16,10 +16,11 @@
  */
 
 import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
+import tools.aqua.GlobalMavenMetadataExtension
 import tools.aqua.MavenMetadataExtension
-import tools.aqua.apache2
-import tools.aqua.developers
+import tools.aqua.developer
 import tools.aqua.github
+import tools.aqua.license
 
 plugins {
   id("tools.aqua.bgw.base-conventions")
@@ -39,15 +40,15 @@ publishing {
         name.set(mavenMetadata.name)
         description.set(mavenMetadata.description)
 
-        github("tudo-aqua", "bgw")
-        licenses { apache2() }
+        val globalMetadata = rootProject.extensions.getByType<GlobalMavenMetadataExtension>()
 
-        developers(
-            "Stefan Naujokat" to "stefan.naujokat@tu-dortmund.de",
-            "Till Schallau" to "till.schallau@tu-dortmund.de",
-            "Dominik Mäckel" to "dominik.maeckel@tu-dortmund.de",
-            "Fabian Klümpers" to "fabian.kluempers@tu-dortmund.de",
-        )
+        developers { globalMetadata.developers.get().forEach { developer(it.name, it.email) } }
+
+        globalMetadata.githubProject.get().let {
+          github(it.organization, it.project, it.mainBranch)
+        }
+
+        licenses { globalMetadata.licenses.get().forEach { license(it.name, it.url) } }
       }
     }
   }

--- a/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
@@ -32,8 +32,6 @@ plugins {
   id("org.jetbrains.kotlinx.kover")
 }
 
-group = "tools.aqua"
-
 version = "0.0.0-SNAPSHOT"
 
 val mavenMetadata = extensions.create<GlobalMavenMetadataExtension>("mavenMetadata")

--- a/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
@@ -18,6 +18,7 @@
 import com.diffplug.gradle.spotless.KotlinExtension
 import com.diffplug.gradle.spotless.KotlinGradleExtension
 import java.util.regex.Pattern
+import tools.aqua.GlobalMavenMetadataExtension
 import tools.aqua.defaultFormat
 
 plugins {
@@ -34,6 +35,8 @@ plugins {
 group = "tools.aqua"
 
 version = "0.0.0-SNAPSHOT"
+
+val mavenMetadata = extensions.create<GlobalMavenMetadataExtension>("mavenMetadata")
 
 gitVersioning.apply {
   describeTagPattern = Pattern.compile("v(?<version>.*)")

--- a/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools.aqua.bgw.root-conventions.gradle.kts
@@ -53,7 +53,7 @@ gitVersioning.apply {
   }
 }
 
-val printVersion by tasks.registering { logger.error(version.toString()) }
+val printVersion by tasks.registering { doFirst { logger.error(version.toString()) } }
 
 spotless {
   format("kotlinBuildSrc", KotlinExtension::class.java) {

--- a/buildSrc/src/main/kotlin/tools/aqua/MavenMetadata.kt
+++ b/buildSrc/src/main/kotlin/tools/aqua/MavenMetadata.kt
@@ -19,14 +19,16 @@ package tools.aqua
 
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.tasks.Input
+import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
 
 /**
  * This extension stores project-specific Maven metadata (name, description) in a type-safe way. The
- * can then be retrieved to fill the POM configuration without forcing build files to contain
+ * values can then be retrieved to fill the POM configuration without forcing build files to contain
  * publishing logic.
  *
  * @param objects a Gradle object factory.
@@ -43,4 +45,57 @@ open class MavenMetadataExtension @Inject constructor(objects: ObjectFactory) {
    * @see MavenPom.getDescription
    */
   @Input val description: Property<String> = objects.property()
+}
+
+/**
+ * This extension stores global Maven metadata (developers, GitHub, license) in a type-safe way. The
+ * values can then be retrieved to fill the POM configuration without forcing build files to contain
+ * publishing logic.
+ *
+ * @param objects a Gradle object factory.
+ */
+open class GlobalMavenMetadataExtension @Inject constructor(objects: ObjectFactory) {
+  /**
+   * A developer's identity.
+   * @param name the developer's name.
+   * @param email the developer's preferred email address.
+   */
+  data class Developer(val name: String, val email: String)
+
+  /**
+   * A GitHub project's coordinates.
+   * @param organization the organisation / user the project resides in.
+   * @param project the project name.
+   * @param mainBranch the main branch (usually "main" or similar).
+   */
+  data class GithubProject(
+      val organization: String,
+      val project: String,
+      val mainBranch: String = "main"
+  )
+
+  /**
+   * A OSS license.
+   * @param name the licenses full name.
+   * @param url a URL with more information about the license.
+   */
+  data class License(val name: String, val url: String)
+
+  /**
+   * The developers for the POM. Uses the root project's developers, if unset.
+   * @see MavenPom.developers
+   */
+  @Input val developers: ListProperty<Developer> = objects.listProperty()
+
+  /**
+   * The developers for the POM. Uses the root project's developers, if unset.
+   * @see MavenPom.developers
+   */
+  @Input val githubProject: Property<GithubProject> = objects.property()
+
+  /**
+   * The developers for the POM. Uses the root project's developers, if unset.
+   * @see MavenPom.developers
+   */
+  @Input val licenses: ListProperty<License> = objects.listProperty()
 }

--- a/buildSrc/src/main/kotlin/tools/aqua/POMMetadata.kt
+++ b/buildSrc/src/main/kotlin/tools/aqua/POMMetadata.kt
@@ -20,6 +20,7 @@ package tools.aqua
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPomDeveloperSpec
 import org.gradle.api.publish.maven.MavenPomLicenseSpec
+import tools.aqua.GlobalMavenMetadataExtension.License
 
 /**
  * Add metadata for a GitHub project. This includes URL and SCM connection data.
@@ -37,14 +38,6 @@ fun MavenPom.github(organization: String, project: String, mainBranch: String = 
 }
 
 /**
- * Add developers using a succinct notation.
- * @param developerPairs the developers' names and email addresses.
- */
-fun MavenPom.developers(vararg developerPairs: Pair<String, String>) {
-  developers { developerPairs.forEach { (name, email) -> developer(name, email) } }
-}
-
-/**
  * Add a developer using a succinct notation.
  * @param developerName the developer's name.
  * @param mailAddress the email address.
@@ -54,8 +47,15 @@ fun MavenPomDeveloperSpec.developer(developerName: String, mailAddress: String) 
   email.set(mailAddress)
 }
 
-/** Add the Apache 2 license specification. */
-fun MavenPomLicenseSpec.apache2() = license {
-  name.set("Apache License, Version 2.0")
-  url.set("https://opensource.org/licenses/Apache-2.0")
+/**
+ * Add a license using a succinct notation.
+ * @param licenseName the license's name.
+ * @param licenseUrl a URL for the license.
+ */
+fun MavenPomLicenseSpec.license(licenseName: String, licenseUrl: String) = license {
+  name.set(licenseName)
+  url.set(licenseUrl)
 }
+
+/** The Apache 2 license. */
+val APACHE_2 = License("Apache License, Version 2.0", "https://opensource.org/licenses/Apache-2.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Add an extension for global metadata to be included into the POM. This includes:

- Developers
- GitHub coordinates
- License(s)

These are now defined in an extension in the root build file. The `group` has been moved to the same file. As a result, less project-defined metadata are now included in the convention plugins, making them more generic and the metadata more discoverable.

In additions, some minor issues (Gradle version, Task bug) were addressed.