### PR TITLE
Custom Gradle Task and production configuration  for BGW-Net Server deployment

### DIFF
--- a/bgw-net/bgw-net-server/build.gradle.kts
+++ b/bgw-net/bgw-net-server/build.gradle.kts
@@ -18,28 +18,45 @@
 plugins { id("tools.aqua.bgw.spring-vaadin-conventions") }
 
 mavenMetadata {
-  name.set("BoardGameWork Server")
-  description.set("A framework for board game applications.")
+    name.set("BoardGameWork Server")
+    description.set("A framework for board game applications.")
 }
 
 dependencies {
-  implementation(project(":bgw-net:bgw-net-common"))
+    implementation(project(":bgw-net:bgw-net-common"))
 
-  implementation(libs.kotlinx.serialization.json)
-  implementation(libs.spring.boot.devtools)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.spring.boot.devtools)
 
-  // json kotlin schema
-  implementation(libs.jackson.kotlin)
-  implementation(libs.jsonSchemaValidator)
+    // json kotlin schema
+    implementation(libs.jackson.kotlin)
+    implementation(libs.jsonSchemaValidator)
 
-  implementation(libs.spring.boot.jpa)
-  implementation(libs.hibernateTypes)
-  runtimeOnly(libs.postgreSQL.jdbc)
+    implementation(libs.spring.boot.jpa)
+    implementation(libs.hibernateTypes)
+    runtimeOnly(libs.postgreSQL.jdbc)
 
-  implementation(libs.spring.boot.websocket)
-  implementation(libs.spring.boot.oauth2.client)
+    implementation(libs.spring.boot.websocket)
+    implementation(libs.spring.boot.oauth2.client)
 
-  // Integration testing
-  testImplementation(libs.h2database.h2)
-  testImplementation(libs.testcontainers.junit.jupiter)
+    // Integration testing
+    testImplementation(libs.h2database.h2)
+    testImplementation(libs.testcontainers.junit.jupiter)
+}
+
+vaadin {
+    productionMode = true
+}
+
+tasks.bootBuildImage {
+    imageName = System.getenv("DOCKER_IMAGE_NAME")
+    environment = mapOf("BP_JVM_VERSION" to "11.*")
+    isPublish = true
+    docker {
+        publishRegistry {
+            username = System.getenv("DOCKER_REGISTRY_USER")
+            password = System.getenv("DOCKER_REGISTRY_PASSWORD")
+            url = System.getenv("DOCKER_REGISTRY_URL")
+        }
+    }
 }

--- a/bgw-net/bgw-net-server/package.json
+++ b/bgw-net/bgw-net-server/package.json
@@ -89,7 +89,7 @@
       "webpack-dev-server": "3.11.0",
       "webpack-merge": "4.2.2"
     },
-    "hash": "bae026311ffe3cf888dab55bab202f502caaeb85fddd06310faf13cc9db02b72"
+    "hash": "ed222a1c0047571306c3bedc6557d984a09d1eb4613f99c3a91ec302cdd659e5"
   },
   "dependencies": {
     "@polymer/iron-a11y-announcer": "3.0.2",

--- a/bgw-net/bgw-net-server/src/main/resources/application-prod.properties
+++ b/bgw-net/bgw-net-server/src/main/resources/application-prod.properties
@@ -1,0 +1,4 @@
+spring.datasource.url = ${POSTGRES_URL}/${POSTGRES_DB}
+spring.datasource.username = ${POSTGRES_USER}
+spring.datasource.password = ${POSTGRES_PASSWORD}
+spring.jpa.hibernate.ddl-auto = update

--- a/bgw-net/bgw-net-server/src/main/resources/application-prod.yml
+++ b/bgw-net/bgw-net-server/src/main/resources/application-prod.yml
@@ -1,0 +1,20 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          gitlab:
+            provider: gitlab
+            client-name: GitLab
+            clientId: ${GITLAB_CLIENT_ID}
+            clientSecret: ${GITLAB_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirectUri:  "http://{baseHost}{basePort}{basePath}/login/oauth2/code/{registrationId}"
+            scope: openid,email,profile
+        provider:
+          gitlab:
+            authorization-uri: ${GITLAB_URL}/oauth/authorize
+            token-uri: ${GITLAB_URL}/oauth/token
+            user-info-uri: ${GITLAB_URL}/oauth/userinfo
+            user-name-attribute: sub
+            jwk-set-uri: ${GITLAB_URL}/oauth/discovery/keys


### PR DESCRIPTION
`./gradlew bootBuildImage`

Set either `SPRING_PROFILES_ACTIVE=prod` variable or pass `-Dspring.profiles.active=prod` flag for loading both `application-prod.yml` and `application-prod.properties` for production mode.