### PR TITLE
Enable styling on ColorVisual

### DIFF
--- a/bgw-gui/src/main/kotlin/tools/aqua/bgw/builder/VisualBuilder.kt
+++ b/bgw-gui/src/main/kotlin/tools/aqua/bgw/builder/VisualBuilder.kt
@@ -69,7 +69,7 @@ object VisualBuilder {
   private fun buildColorVisual(visual: ColorVisual) =
       Pane().apply {
         visual.colorProperty.setGUIListenerAndInvoke(visual.color) { _, nV ->
-          style = "-fx-background-color: #${"%02x".format(nV.rgb).substring(2)};"
+          style = "-fx-background-color: #${"%02x".format(nV.rgb).substring(2)};" + visual.style
           opacity = nV.alpha / MAX_HEX * visual.transparency
         }
 

--- a/bgw-gui/src/main/kotlin/tools/aqua/bgw/visual/ColorVisual.kt
+++ b/bgw-gui/src/main/kotlin/tools/aqua/bgw/visual/ColorVisual.kt
@@ -21,6 +21,7 @@ package tools.aqua.bgw.visual
 
 import java.awt.Color
 import tools.aqua.bgw.observable.properties.Property
+import tools.aqua.bgw.observable.properties.StringProperty
 
 /**
  * A solid color visual. Displays a rectangle filled with the given [color].
@@ -40,6 +41,24 @@ open class ColorVisual(color: Color) : SingleLayerVisual() {
    * @see color
    */
   val colorProperty: Property<Color> = Property(color)
+
+  /**
+   * [Property] for the css style that gets applied to this [ColorVisual].
+   *
+   * @see style
+   */
+  val styleProperty: StringProperty = StringProperty("")
+
+  /**
+   * Css style that gets applied to this [ColorVisual].
+   *
+   * @see styleProperty
+   */
+  var style: String
+    get() = styleProperty.value
+    set(value) {
+      styleProperty.value = value
+    }
 
   /**
    * The displayed [Color] of this [Visual].
@@ -73,6 +92,7 @@ open class ColorVisual(color: Color) : SingleLayerVisual() {
   override fun copy(): ColorVisual =
       ColorVisual(Color(color.red, color.green, color.blue, color.alpha)).apply {
         transparency = this@ColorVisual.transparency
+        style = this@ColorVisual.style
       }
 
   companion object {


### PR DESCRIPTION
It is currently not possible to add styling tags to any objects apart from `UIComponents`. To add a bit more flexibility, `ColorVisuals` should be able to get styled, to add the possibility of for example rounding corners on the background color of `GridPane`s.