### PR TITLE
Fix finding rollback of DragDrop on Panes

### DIFF
--- a/bgw-gui/src/main/kotlin/tools/aqua/bgw/builder/DragDropBuilder.kt
+++ b/bgw-gui/src/main/kotlin/tools/aqua/bgw/builder/DragDropBuilder.kt
@@ -168,7 +168,7 @@ object DragDropBuilder {
     return {
       @Suppress("UNCHECKED_CAST")
       (this as Pane<ComponentView>).add(
-          this as ComponentView, min(observableComponents.size, index))
+          component, min(observableComponents.size, index))
     }
   }
   // endregion


### PR DESCRIPTION
This seems to be a simple typo, responsible for crashing the game when dropping a draggable at a non-droppable location, leading to the rollback of the component to its original position. Using the current implementation, the framework tries to add the surrounding component to itself, doing nothing in the cause of the draggable object and throwing errors on-the-way.