### PR TITLE
core: Add loading font from InputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
  - onScroll event.
  - Style property for SingleLayerVisuals.
  - flip() function in CardView.
+ - loadFont(InputStream) for loading custom fonts from within .jar-files.
 
 ### Changed
  - BoardGameApplication.runOnGUIThread may now be called without starting an application for headless testing.

--- a/bgw-docs/src/main/jekyll/components/uicomponents/uicomponents.md
+++ b/bgw-docs/src/main/jekyll/components/uicomponents/uicomponents.md
@@ -357,9 +357,8 @@ In order to load a custom font use the [BoardGameApplication][BoardGameApplicati
 
 ````kotlin
 // Load Roboto-Regular.ttf from root of resource folder 
-val resource = UIComponentExample::class.java.getResource("/Roboto-Regular.ttf") ?: throw FileNotFoundException()
-val fontFile = File(resource.toURI())
-BoardGameApplication.loadFont(fontFile)
+val fontStream = SwimApplication::class.java.getResourceAsStream("/Roboto-Regular.ttf") ?: throw FileNotFoundException()
+BoardGameApplication.loadFont(fontStream)
 ````
 Now the font is registered and ready to use.
 

--- a/bgw-gui/src/main/kotlin/tools/aqua/bgw/core/BoardGameApplication.kt
+++ b/bgw-gui/src/main/kotlin/tools/aqua/bgw/core/BoardGameApplication.kt
@@ -33,6 +33,7 @@ import tools.aqua.bgw.event.KeyEvent
 import tools.aqua.bgw.observable.properties.Property
 import tools.aqua.bgw.visual.ImageVisual
 import tools.aqua.bgw.visual.Visual
+import java.io.InputStream
 
 /**
  * Baseclass for all BGW Applications. Extend from this class in order to create your own game
@@ -354,7 +355,17 @@ open class BoardGameApplication(
 
     /**
      * Loads a font file and registers it in the JFX graphics system.
-     * @param font The font file off type .ttf which is to be loaded
+     * @param fontStream An input stream to the font file of type .ttf which is to be loaded
+     * @return A boolean weather the font could be loaded or not
+     */
+    fun loadFont(fontStream: InputStream): Boolean {
+      val jfxFont = JFXFont.loadFont(fontStream, DEFAULT_FONT_SIZE) ?: return false
+      return JFXFont.getFamilies().contains(jfxFont.family)
+    }
+
+    /**
+     * Loads a font file and registers it in the JFX graphics system.
+     * @param font The font file of type .ttf which is to be loaded
      * @throws NoSuchFileException if the file doesn't exist
      * @throws AccessDeniedException if the file can't be read
      * @return A boolean weather the file could be loaded or not
@@ -362,8 +373,7 @@ open class BoardGameApplication(
     fun loadFont(font: File): Boolean {
       if (!font.exists()) throw NoSuchFileException(font)
       if (!font.canRead()) throw AccessDeniedException(font)
-      val jfxFont = JFXFont.loadFont(font.inputStream(), DEFAULT_FONT_SIZE) ?: return false
-      return JFXFont.getFamilies().contains(jfxFont.family)
+      return loadFont(font.inputStream())
     }
   }
 }


### PR DESCRIPTION
As fonts cannot be loaded from jarfiles, this PR adds another method to parse fonts from an InputStream instead of Files, so no workaround using temporary files has to be used.

Closes #327, #323

Co-authored-by: @nelsbrock
Co-authored-by: @p4czyk