### PR TITLE
Enable dependabot (daily updates, Gradle and GH actions ecosystems)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- Dependabot enabled
+
 ## [0.8.1] - 21.07.2023
 
 ### Fixed


### PR DESCRIPTION
This adds a simple Dependabot configuration file.